### PR TITLE
Add SPICE-0002 on URI rewriting

### DIFF
--- a/spice-templates/SPICE-0000-pkl-template.adoc
+++ b/spice-templates/SPICE-0000-pkl-template.adoc
@@ -1,6 +1,6 @@
 = SPICE Name
 
-* Proposal: [SPICE-NNNN](./SPICE-NNNN-name-of-proposal.adoc)
+* Proposal: link:./NNNN-name-of-proposal.adoc[SPICE-NNNN]
 * Status: Accepted or Rejected
 * Implemented in: Pkl <version>
 * Category: Language, Standard Library, Tooling

--- a/spices/0002-uri-rewriting-for-mirroring.adoc
+++ b/spices/0002-uri-rewriting-for-mirroring.adoc
@@ -1,0 +1,319 @@
+= SPICE 2: URI Rewriting for Mirroring
+
+* Proposal: link:./0002-uri-rewriting-for-mirroring.adoc[SPICE-0002]
+* Author: link:https://github.com/holzensp[Philip Hölzenspies]
+* Status: Review
+* Implemented in: Pkl 0.26.0
+* Category: Tooling
+
+== Introduction
+
+This SPICE discusses rewrite rules for URIs of modules being `import`ed, so as to use mirrored alternatives.
+
+== Motivation
+
+For systems that require run-time air-gapping, packages imported from `pkg.pkl-lang.org` or other sites on the internet are not available.
+This can be remedied by pre-populating a cache directory with all required dependencies (see link:../spices/0001-import-graph-analyzer.pkl[SPICE 1: Import Graph Analyzer API]).
+When dependencies can not be determined ahead of time, pre-populating the cache is not an option.
+Mirroring packages from internet repositories in a local store is insufficient, because the mirrored packages may have hard-coded dependencies.
+Importing mirrored packages, using URIs pointing to the mirror, will eventually evaluate `import`s of those hard-coded dependencies, referring to external sites.
+
+Another reason to want to consume (transitive) dependencies from a mirror is the requirement of altered versions of packages.
+For example, redirecting a package developed for `github.com` to point to a GitHub Enterprise instance.
+Note that, because upstream dependencies specify the SHA256 hash, altering packages on a mirror requires _all upstream dependants to be updated_.
+This SPICE does _not_ provide further facilities for altering packages when mirroring.
+
+== Proposed Solution
+
+Similar to `git-config`'s `insteadOf`, the proposed solution is to rewrite URIs when used in `import`, `import*`, `amends`, `extends`, `read`, and `read*` clauses/expressions.
+From `git-config`'s `man` page, on `url.<base>.insteadOf`:
+
+> Any URL that starts with this value will be rewritten to start, instead, with `<base>`.
+> In cases where some site serves a large number of repositories, and serves them with multiple access methods, and some users need to use different access methods, this feature allows people to specify any of the equivalent URLs and have Git automatically rewrite the URL to the best alternative for the particular user, even for a never-before-seen repository on the site.
+> When more than one insteadOf strings match a given URL, the longest match is used.
+>
+> Note that any protocol restrictions will be applied to the rewritten URL.
+> If the rewrite changes the URL to use a custom protocol or remote helper, you may need to adjust the `protocol.*.allow` config to permit the request.
+
+The solution proposed in this SPICE mirrors this design, but extends it to allow regular expressions for the match.
+Only after rewriting are URIs tested for compliance with Allowed Modules and Allowed Resources settings.
+
+Rewrites can be provided:
+
+1. Via the API;
+2. Via `pkl:Project`; and
+3. Via arguments on the CLI.
+
+== Detailed design
+
+=== API
+
+The API changes described here refer to the Java API, but this SPICE implies analogous changes to the Swift and Go APIs.
+
+The `EvaluatorBuilder` gets the following new methods:
+
+[source,java]
+----
+public final class EvaluatorBuilder {
+    // ...
+
+    /**
+     * Adds the given URI rewrite rule.
+     *
+     * @param replace   The literal string to match.
+     * @param with      The literal string to substitute for the first match of [replace].
+     */
+    public EvaluatorBuilder addRewriteRule(String replace, String with) {
+        // ...
+    }
+
+    /**
+     * Adds the given URI rewrite rule.
+     *
+     * @param replace   The regular expression to match.
+     * @param with      The string to substitute for the first match of [replace], which may contain
+     *                  references to capture groups (`$0`, `$1`, etc).
+     */
+    public EvaluatorBuilder addRewriteRule(Pattern replace, String with) {
+        // ...
+    }
+}
+----
+
+=== Standard library module `pkl:Project`
+
+Rewrite rules can be defined project-wide by declaring them in the `PklProject` file.
+
+[source,pkl]
+----
+@Since { version = "0.26.0" }
+class UriRewrite {
+  /// What to match in the given URI.
+  replace: String|Regex
+
+  /// What to replace the _all_ matches with.
+  ///
+  /// When `replace` is a `String`, `with` is interpreted literally.
+  /// When `replace` is a `Regex`, `with` is interpreted as a replacement pattern,
+  /// which may contain references to capture groups (`$0`, `$1`, etc).
+  with: String
+}
+
+/// Rewrite rules for URIs used in module keys and resource reads.
+///
+/// For any URI, the first of the longest-matching [UriRewrite]s is applied, before applying the secutiry manager.
+@Since { version = "0.26.0" }
+uriRewrites: Listing<UriRewrite>
+----
+
+=== Common CLI flags
+
+These flags are _common_, because this setting applies to different commands equally.
+The proposed `analyze` command (see link:../spices/0001-import-graph-analyzer.pkl[SPICE 1: Import Graph Analyzer API]), for example, applies these rewrites in the resolution of all URIs analyzed and reported.
+
+This proposal adds two flags to the CLI:
+  * `--uri-rewrite <regex> <replacement>`, which adds a URI rewrite rule; and
+  * `--no-uri-rewrites`, which discards all URI rewrite rules defined thus far.
+
+If a `pkl:Project` file is found, this is read first.
+To invoke Pkl without rewrite rules defined therein, `--no-uri-rewrites` can be used, followed by zero-or-more `--uri-rewrite` arguments.
+
+=== Rewrite behavior
+
+The proposed design is to match any URI being resolved in its entirety to all the provided rewrites' `replace` specification.
+The first, longest-matching rewrite rule is applied.
+In other words:
+ - when multiple rules match, a rule that matches a longer substring of the URI is preferred over one matching a shorter substring; and
+ - when multiple rules match the same substring length, the first rule is chosen (in definition order).
+
+The intended rewrite behavior, expressed as Pkl, is
+[source, pkl]
+----
+class Rewrite {
+  rewrites: List<UriRewrite>
+  uri: Uri
+
+  matchesByScore = rewrites.groupBy((rewrite) ->
+    if (!uri.contains(rewrite.replace))
+      -1
+    else if (rewrite.replace is Regex)
+      let (match = rewrite.replace.findMatchesIn(uri).first)
+        match.end - match.start
+    else
+      rewrite.replace.length
+  )
+
+  maxScore = matchesByScore.keys.max
+
+  rewritten: Uri = if (maxScore == -1) uri else
+    let (rewrite = matchesByScore[maxScore].first)
+      uri.replaceFirst(rewrite.replace, rewrite.with)
+}
+
+function rewrite(inputUri: Uri, uriRewrites: List<UriRewrite>): Uri = new Rewrite {
+  rewrites = uriRewrites
+  uri = inputUri
+}.rewritten
+----
+
+=== Implementation
+
+The proposed design is to implement this behaviour in `IoUtils::resolve`.
+`IoUtils::resolve` is used throughout to resolve URIs, regardless of whether a URI is used in an `import`, `import*`, `extends`, `amends`, `read`, or `read*`.
+
+=== Error messages
+
+Rewriting URIs according to definitions _not_ in the modules being evaluated could lead to hard to debug failures.
+When a rewritten URI points to an invalid resource, for example, users must be informed of the URIs provenance.
+The solution is to present the URI rewrite as a stack frame, identifying the applied rewrite rule.
+
+Rewriting is reported as follows
+[source]
+----
+Rewriting URI <URI_as_in_Pkl_code>
+  replacing "<string_or_regex_from_applied_rule>"
+  with "<replacement_string_from_applied_rule>"
+at <source_position_of_applied_rule>
+----
+
+As an example, consider a file `PklProject`, which defines
+[source,pkl]
+----
+amends "pkl:Project"
+
+uriRewrites {
+  new {
+    replace = "example.com"
+    with = "domain-that-does-not-really-exist.con"
+  }
+}
+----
+and a file `attempt.pkl` containing
+[source,pkl]
+----
+import "https://example.com/dependency.pkl"
+
+name = dependency.name
+----
+
+Evaluating this wants to resolve `import "https://example.com/dependency.pkl"`, which triggers the rewrite rule to produce the rewritten URI `https://domain-that-does-not-really-exist.con/dependency.pkl`.
+Since the rewritten URI points to a non-existent domain, Pkl produces an error:
+
+[source,bash]
+----
+$ pkl eval attempt.pkl
+–– Pkl Error ––
+I/O error loading module `https://domain-that-does-not-really-exist.con/dependency.pkl`.
+UnknownHostException: domain-that-does-not-really-exist.con
+
+Rewriting URI "https://example.com/dependency.pkl"
+  replacing "example.com"
+  with "domain-that-does-not-really-exist.con"
+at PklProject (file:///Users/jappleseed/demo/PklProject, line 4)
+
+1 | import "https://domain-that-does-not-really-exist.con/dependency.pkl"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at attempt#dependency (file:///Users/jappleseed/demo/attempt.pkl, line 1)
+
+3 | name = dependency.name
+           ^^^^^^^^^^
+at attempt#name (file:///Users/jappleseed/demo/attempt.pkl, line 3)
+
+106 | text = renderer.renderDocument(value)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+at pkl.base#Module.output.text (https://github.com/apple/pkl/blob/0.25.2/stdlib/base.pkl#L106)
+----
+
+== Compatibility
+
+The proposed solution is backwards compatible in the sense that modules that can be successfully evaluated with Pkl prior to this SPICE, still can.
+Since the solution involves an addition to `pkl:Project` and the API, usages of this SPICE break evaluation when used with previous versions of Pkl.
+
+== Alternatives Considered
+
+=== Doing nothing
+
+The responsibility for implementing mirroring could be left to other components in the system.
+If support for HTTP proxies is implemented, for example, the rewrite responsibility could be delegated to a proxy.
+However, there are common (forward) proxy implementation that do *not* offer such a facility.
+
+Alternatively, packages can be rewritten when populating a mirror.
+This requires detailed knowledge of Pkl in the mirror implementation.
+Since the URIs for `read`s can be computed (are not statically known), a correct, full rewrite ahead of the intended evaluation is impossible.
+
+The rewrite requirements are too Pkl-specific to rely on delegation.
+
+=== Rewriting only `http`/`https`/`package`/`projectpackage` URIs
+
+This would exclude this facility from usage on people's custom resource readers and module key factories, limiting the use of those SPIs.
+
+=== More expressive rewrite definitions
+
+The definition in `UriRewrite` of `with: String` allows for match group substitutions, but not for general computation.
+This can be made more expressive by defining it as `with: String|((RegexMatch) -> String)`.
+Although this would indeed make `pkl:Project` more expressive, the API and CLI definition cases are less amenable to this solution.
+In the API case, users would have to programmatically construct Truffle node instances.
+The CLI would require significant parsing support, or impose prohibitive string escaping requirements.
+Introducing arbitrary functions into the evaluation of modules from `pkl:Project` also has implications for performance and error messages.
+All of these are considered detrimental to the user experience.
+
+
+== Usage examples
+
+=== Context-dependent rewrite rule sets
+
+If some rewrites only apply to tests, or parts of a repository, they could all be defined on the CLI.
+This can become cumbersome to maintain, since this means they are defined in (typically non-Pkl) build configuration files.
+However, since a `PklProject` may amend another `PklProject` file, rewrite rules can be kept in Pkl modules that amend a common root `PklProject` file.
+
+Taking testing as an example, you can keep the following file structure:
+----
+.
+├── PklProject         // <1>
+├── src
+│   └── foo.pkl
+└── test
+    ├── foo_test.pkl
+    └── PklProject    // <2>
+----
+<1> Defines common URI rewrite rules and `amends "pkl:Project"`.
+<2> Defines URI rewrite rules used only for testing and `amends "..."`.
+
+Running `pkl test foo_test.pkl` applies all the rules for the testing context.
+
+=== Test rewrite rules
+
+No new facilities are required for `pkl:test` to cover rewrite rules.
+
+An easy way to perform positive tests (testing whether rewrite rules _have_ been applied) is to disallow all module keys and to test that the expected rewritten URIs occur in the exception.
+Negative tests are similar, except the assertion is that the exception contains the original URI.
+For example, if `"github.com"` is rewritten to `"github.example.com"`, and URIs pointing at `example.com` should not be rewritten, the following test passes when run with `pkl test --allowed-modules file test.pkl`:
+
+[source,pkl]
+----
+amends "pkl:test"
+
+facts {
+  ["github.com URIs are pointed at the example.com GHE instance"] {
+    module.catch(() -> import("https://github.com/foo/bar.pkl"))
+      .contains("https://github.example.com/foo/bar.pkl")
+  }
+  ["example.com URIs are *not* rewritten"] {
+    module.catch(() -> import("https://example.com/foo/bar.pkl"))
+      .contains("https://example.com/foo/bar.pkl")
+  }
+}
+----
+
+=== DENY default rule
+
+When URI rewrite rules are used to ensure no remote resources are used at all, a rule to check "all URIs not touched by any of the rewrite rules are rejected" can be expressed.
+This rule is based on the fact that it matches at zero-width, so no other rule has a lower score:
+
+[source,pkl]
+----
+  new UriRewrite {
+    replace = Regex("^")
+    with = throw("URI found that is uncovered by any of the rewrite rules")
+  }
+----


### PR DESCRIPTION
This adds a SPICE for URI rewriting for e.g. running Pkl in air-gapped / mirroring environments.